### PR TITLE
[GRDM-40847] helmチャート追随にともなうfsGroupのvalue指定の変更

### DIFF
--- a/jupyterhub/templates/schedulable-notebook/deployment.yaml
+++ b/jupyterhub/templates/schedulable-notebook/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           persistentVolumeClaim:
             claimName: schedulable-notebook-home
       securityContext:
-        fsGroup: {{ .Values.hub.fsGid }}
+        fsGroup: {{ .Values.hub.podSecurityContext.fsGroup }}
         fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - command:


### PR DESCRIPTION
hub.fsGidという設定が以前のバージョンでは利用可能でしたが、バージョン2.0.0以降では代わりにhub.podSecurityContext.fsGroupという設定に変わったため。